### PR TITLE
Add lang URL parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ instance-agnostic. Just type in the post text and the instance URL, and click
 ‘Post!’
 
 Or, open this page with the prefilled `text` URL parameter—it will be
-automatically inserted into the text field. The same goes for the `instance` URL
-parameter. This can be used to build custom share buttons for the federated
-social networks:
+automatically inserted into the text field. The same goes for the `instance` and
+`lang` URL parameters. This can be used to build custom share buttons for the
+federated social networks:
 
 ```html
 <a href="https://s2f.kytta.dev/?text=Hello%20world!&instance=mastodon.xyz">

--- a/src/i18n/engine.ts
+++ b/src/i18n/engine.ts
@@ -12,6 +12,11 @@ export function useTranslations(language: string) {
 }
 
 export function findBestLanguage(): string {
+	const urlLanguage = new URLSearchParams(window.location.search).get("lang");
+	if (urlLanguage && urlLanguage in languages) {
+		return urlLanguage;
+	}
+
 	let browserLanguages = navigator.languages;
 	if (!navigator.languages) browserLanguages = [navigator.language];
 	for (const language of browserLanguages) {


### PR DESCRIPTION
Follow-up to #43 

Accept a `lang=` parameter to specify a custom language. This can help when creating a custom share button where you want to specify the language.