### PR TITLE
Set Crawl-Delay for MJ12Bot

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,7 @@
 User-agent: *
 Disallow: /
+
+# Well-known overly-aggressive bot that claims to respect robots.txt: http://mj12bot.com/
+User-agent: MJ12bot
+Disallow: /
+Crawl-Delay: 10


### PR DESCRIPTION
MJ12Bot, apparently, a well-known bot that claims to respect robots.txt, but doesn't. This causes s2f.kytta.dev to get way too many requests from it. While I already block the via Vercel Firewall, it might be a good idea to set an explicit Crawl-Delay.

Cherry-picked from #108