### PR TITLE
Improve popular instances fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ official Docker images.
 
 ### Fixed
 
+- popular instances (`/api/instances` endpoint, and the instance selector dropdown)
+  should no longer be slow and flaky thanks to excessive caching
 - fixed duplicate "on on GitHub" in some translations
 - multiple vulnerable dependencies were patched
 - errors on invalid domain names are now human-readable (thx [Kirill](https://github.com/vetrovk)!)

--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -45,15 +45,13 @@ const getInstancesForProject = async (
 ): Promise<Instance[]> => {
 	let instances: Instance[];
 
-	const headers = new Headers();
-	headers.set("Accept", "application/graphql-response+json; charset=utf-8");
-	headers.append("Accept", "application/json; charset=utf-8");
-	headers.set("Content-Type", "application/json");
-	headers.set("User-Agent", `Share2Fedi/${version} (+${repository.url})`);
-
 	try {
 		const response = await fetch("https://api.fediverse.observer/", {
-			headers,
+			headers: {
+				Accept: "application/graphql-response+json, application/json",
+				"Content-Type": "application/json",
+				"User-Agent": `Share2Fedi/${version} (+${repository.url})`,
+			},
 			body: JSON.stringify({
 				query,
 				variables: { softwarename: project },

--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -40,11 +40,23 @@ const query = `
 	}
 `;
 
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const instancesCache: Map<
+	keyof typeof supportedProjects,
+	{ value: Instance[] | undefined; lastFetched: number }
+> = new Map();
+
 const getInstancesForProject = async (
 	project: keyof typeof supportedProjects,
 ): Promise<Instance[]> => {
-	let instances: Instance[];
+	if (
+		instancesCache.get(project)?.value &&
+		Date.now() - instancesCache.get(project)!.lastFetched < CACHE_TTL_MS
+	) {
+		return instancesCache.get(project)!.value!;
+	}
 
+	let instances: Instance[];
 	try {
 		const response = await fetch("https://api.fediverse.observer/", {
 			headers: {
@@ -62,15 +74,25 @@ const getInstancesForProject = async (
 		instances = json.data.nodes;
 	} catch (error) {
 		console.error(`Could not fetch instances for "${project}"`, error);
-		return [];
+		return []; // not caching invalid result
 	}
 
-	return instances.filter(
+	const domains = instances.filter(
 		(instance) =>
 			instance.score > 90 &&
 			// sanity check for some spammy-looking instances
 			instance.total_users >= instance.active_users_monthly,
 	);
+
+	// only cache if not empty
+	if (domains.length > 0) {
+		instancesCache.set(project, {
+			value: domains,
+			lastFetched: Date.now(),
+		});
+	}
+
+	return domains;
 };
 
 export const getPopularInstanceDomains = async (): Promise<string[]> => {

--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -29,6 +29,17 @@ interface Instance {
 	total_users: number;
 }
 
+const query = `
+	query ($softwarename: String!) {
+		nodes(softwarename: $softwarename, status: "UP") {
+			domain
+			score
+			active_users_monthly
+			total_users
+		}
+	}
+`;
+
 const getInstancesForProject = async (
 	project: keyof typeof supportedProjects,
 ): Promise<Instance[]> => {
@@ -44,8 +55,8 @@ const getInstancesForProject = async (
 		const response = await fetch("https://api.fediverse.observer/", {
 			headers,
 			body: JSON.stringify({
-				query: `query($project:String!){nodes(status:"UP",softwarename:$project){domain score active_users_monthly total_users}}`,
-				variables: { project },
+				query,
+				variables: { softwarename: project },
 			}),
 			method: "POST",
 		});

--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -6,11 +6,21 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { supportedProjects } from "./project";
+import { type supportedProjects } from "./project";
 import {
 	version,
 	repository,
 } from "../../package.json" assert { type: "json" };
+
+// Testing has shown that top 200 fediverse servers run these projects' software.
+// This way, we can avoid checking all 10+ projects we support
+const POPULAR_SOFTWARES = [
+	"mastodon",
+	"fedibird",
+	"misskey",
+	"friendica",
+	"sharkey",
+] satisfies Array<keyof typeof supportedProjects>;
 
 interface Instance {
 	domain: string;
@@ -56,9 +66,7 @@ const getInstancesForProject = async (
 
 export const getPopularInstanceDomains = async (): Promise<string[]> => {
 	const instancesPerProject = await Promise.all(
-		Object.keys(supportedProjects).map((project) =>
-			getInstancesForProject(project),
-		),
+		POPULAR_SOFTWARES.map((project) => getInstancesForProject(project)),
 	);
 	const instances = instancesPerProject.flat();
 	instances.sort((a, b) => b.active_users_monthly - a.active_users_monthly);

--- a/src/pages/api/instances.ts
+++ b/src/pages/api/instances.ts
@@ -16,7 +16,7 @@ export const GET: APIRoute = async () => {
 	return json(popularInstanceDomains, 200, {
 		"Cache-Control":
 			popularInstanceDomains.length > 0
-				? "public, s-maxage=604800, max-age=604800"
+				? "public, s-maxage=604800, max-age=604800, stale-while-revalidate=2419200"
 				: "public, s-maxage=60, max-age=3600",
 	});
 };


### PR DESCRIPTION
This PR improves fetching of popular instances and code around it:

- **Add caching.** Instances are cached per-project for a day, in memory. While the instances are fresh, the response uses them.
- **Only fetch five softwares.** A quick test has shown that Mastodon, Fedibird, Misskey, Friendica, and Sharkey account for the top 200 instance, so we don't have to molest fediverse.observer with 12 queries on each request :D
- Clients are now allowed to use stale responses for a month
- Cleaned up code around requests a bit

Locally, requests from `/api/instances` take 2ms on warm cache and ~200ms on cold cache. Ideally, each instance of S2F should only ping f.o once a day, which is more than enough. I believe this closes #84.